### PR TITLE
chore: update action to new repository location

### DIFF
--- a/.github/workflows/_sync_secrets.yml
+++ b/.github/workflows/_sync_secrets.yml
@@ -77,7 +77,7 @@ jobs:
                 })
               })
       - name: Sync Secrets
-        uses: google/secrets-sync-action@v1.7.1
+        uses: jpoehnelt/secrets-sync-action@v1.7.1
         if: ${{ github.event_name == 'pull_request' }}
         with:
           secrets: ${{ env.SECRETS_SYNC }}
@@ -133,7 +133,7 @@ jobs:
                 })
               })
       - name: Sync Secrets
-        uses: google/secrets-sync-action@v1.7.1
+        uses: jpoehnelt/secrets-sync-action@v1.7.1
         if: ${{ github.event_name == 'workflow_dispatch' }}
         with:
           secrets: ${{ env.SECRETS_SYNC }}


### PR DESCRIPTION
This is a PR to update the action to the new repository location from https://github.com/google/secrets-sync-action to https://github.com/jpoehnelt/secrets-sync-action. Note that GitHub does redirect the old repository to the new one, so this is more housekeeping than anything else.