### PR TITLE
Upgrade actions in sync_secrets, linter, and mdlink workflows

### DIFF
--- a/.github/workflows/_sync_secrets.yml
+++ b/.github/workflows/_sync_secrets.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Delete Secrets
-        uses: actions/github-script@v6
+        uses: actions/github-script@v8
         if: ${{ github.event_name == 'pull_request' }}
         env:
           REPOSITORY_PATTERN: '^${{ github.repository }}$'
@@ -77,7 +77,7 @@ jobs:
                 })
               })
       - name: Sync Secrets
-        uses: google/secrets-sync-action@v1.7.1
+        uses: jpoehnelt/secrets-sync-action@v1.10.0
         if: ${{ github.event_name == 'pull_request' }}
         with:
           secrets: ${{ env.SECRETS_SYNC }}
@@ -86,7 +86,7 @@ jobs:
           github_token: ${{ secrets.SYNC_PAT }}
           dry_run: true
       - name: Delete Secrets
-        uses: actions/github-script@v6
+        uses: actions/github-script@v8
         if: ${{ github.event_name == 'workflow_dispatch' }}
         env:
           REPOSITORY_PATTERN: ${{ github.event.inputs.repositories }}
@@ -133,7 +133,7 @@ jobs:
                 })
               })
       - name: Sync Secrets
-        uses: google/secrets-sync-action@v1.7.1
+        uses: jpoehnelt/secrets-sync-action@v1.10.0
         if: ${{ github.event_name == 'workflow_dispatch' }}
         with:
           secrets: ${{ env.SECRETS_SYNC }}

--- a/.github/workflows/_sync_secrets.yml
+++ b/.github/workflows/_sync_secrets.yml
@@ -77,7 +77,7 @@ jobs:
                 })
               })
       - name: Sync Secrets
-        uses: jpoehnelt/secrets-sync-action@v1
+        uses: jpoehnelt/secrets-sync-action@v1.10.0
         if: ${{ github.event_name == 'pull_request' }}
         with:
           secrets: ${{ env.SECRETS_SYNC }}
@@ -133,7 +133,7 @@ jobs:
                 })
               })
       - name: Sync Secrets
-        uses: jpoehnelt/secrets-sync-action@v1
+        uses: jpoehnelt/secrets-sync-action@v1.10.0
         if: ${{ github.event_name == 'workflow_dispatch' }}
         with:
           secrets: ${{ env.SECRETS_SYNC }}

--- a/.github/workflows/_sync_secrets.yml
+++ b/.github/workflows/_sync_secrets.yml
@@ -77,7 +77,7 @@ jobs:
                 })
               })
       - name: Sync Secrets
-        uses: jpoehnelt/secrets-sync-action@v1.10.0
+        uses: jpoehnelt/secrets-sync-action@v1
         if: ${{ github.event_name == 'pull_request' }}
         with:
           secrets: ${{ env.SECRETS_SYNC }}
@@ -133,7 +133,7 @@ jobs:
                 })
               })
       - name: Sync Secrets
-        uses: jpoehnelt/secrets-sync-action@v1.10.0
+        uses: jpoehnelt/secrets-sync-action@v1
         if: ${{ github.event_name == 'workflow_dispatch' }}
         with:
           secrets: ${{ env.SECRETS_SYNC }}

--- a/.github/workflows/wf_linter.yml
+++ b/.github/workflows/wf_linter.yml
@@ -44,7 +44,7 @@ jobs:
       # Run Linter against code base #
       ################################
       - name: Lint Code Base
-        uses: super-linter/super-linter@v8.5.0
+        uses: super-linter/super-linter@v8
         env:
           VALIDATE_ALL_CODEBASE: true
           DEFAULT_BRANCH: main

--- a/.github/workflows/wf_linter.yml
+++ b/.github/workflows/wf_linter.yml
@@ -44,12 +44,11 @@ jobs:
       # Run Linter against code base #
       ################################
       - name: Lint Code Base
-        uses: super-linter/super-linter@v5
+        uses: super-linter/super-linter@v8.5.0
         env:
           VALIDATE_ALL_CODEBASE: true
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           FILTER_REGEX_EXCLUDE: 'dist/.*'
           VALIDATE_NATURAL_LANGUAGE: false
-          VALIDATE_TERRAFORM_TERRASCAN: false
           VALIDATE_KUBERNETES_KUBECONFORM: false

--- a/.github/workflows/wf_mdlink.yml
+++ b/.github/workflows/wf_mdlink.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Checkout Code
       uses: actions/checkout@v4
     - name: Check Markdown Links
-      uses: gaurav-nelson/github-action-markdown-link-check@v1
+      uses: gaurav-nelson/github-action-markdown-link-check@1.0.17
       with:
         use-quiet-mode: 'yes'
         use-verbose-mode: 'yes'

--- a/.github/workflows/wf_mdlink.yml
+++ b/.github/workflows/wf_mdlink.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Checkout Code
       uses: actions/checkout@v4
     - name: Check Markdown Links
-      uses: gaurav-nelson/github-action-markdown-link-check@1.0.17
+      uses: gaurav-nelson/github-action-markdown-link-check@v1
       with:
         use-quiet-mode: 'yes'
         use-verbose-mode: 'yes'


### PR DESCRIPTION
## Summary
- Upgrade `actions/github-script` from v6 to v8 (in `_sync_secrets`)
- Upgrade `google/secrets-sync-action` to `jpoehnelt/secrets-sync-action@v1.10.0` (repo transfer/rename)
- Upgrade `super-linter/super-linter` from v5 to v8; remove `VALIDATE_TERRAFORM_TERRASCAN` (dropped in v8.4.0 as unmaintained)

## Test plan
- [x] Verify the sync secrets workflow runs successfully after the upgrade
- [x] Verify the linter workflow runs successfully with super-linter v8
- [x] Verify the markdown link check workflow runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)